### PR TITLE
avoid new Buffer DeprecationWarning

### DIFF
--- a/flake-id-gen.js
+++ b/flake-id-gen.js
@@ -51,8 +51,14 @@
            * @param {Buffer} id - Generated id
            */
 
-            var id = new Buffer(8), time = Date.now() - this.epoch;
-            id.fill(0);
+            var id;
+            if (Buffer.alloc) {
+                id = Buffer.alloc(8);
+            } else {
+                id = new Buffer(8);
+                id.fill(0);
+            }
+            var time = Date.now() - this.epoch;
 
             // Generates id in the same millisecond as the previous id
             if (time === this.lastTime) {


### PR DESCRIPTION
with Node.js 10, we get a deprecation warning because of new Buffer usage. Buffer.alloc is prefered. Testing Buffer.alloc is available makes this PR backward compatible.